### PR TITLE
Allow explicit column selection in CraterDatabase

### DIFF
--- a/craterpy/classes.py
+++ b/craterpy/classes.py
@@ -54,6 +54,11 @@ class CraterDatabase:
         body: str,
         input_crs: str | CRS = "default",
         units: str = "m",
+        *,
+        lat_col: str | None = None,
+        lon_col: str | None = None,
+        rad_col: str | None = None,
+        diam_col: str | None = None,
     ):
         """
         Initialize a CraterDatabase.
@@ -70,12 +75,21 @@ class CraterDatabase:
             or a valid pyproj.CRS object.
         units : str
             Length units of radius/diameter column, 'm' or 'km' (default: 'm')
+        lat_col, lon_col : str, optional
+            Names of the latitude/longitude columns. If omitted, they are
+            auto-detected from common names.
+        rad_col, diam_col : str, optional
+            Name of the radius or diameter column (pass only one). If omitted, a
+            radius/diameter column is auto-detected from common names.
 
         Raises
         ------
             ValueError
-                If dataset is not a file or is not a pandas.DataFrame.
+                If dataset is not a file or is not a pandas.DataFrame, if both
+                rad_col and diam_col are given, or if a named column is missing.
         """
+        if rad_col is not None and diam_col is not None:
+            raise ValueError("Specify only one of rad_col or diam_col.")
         self.body = body.lower()
         self._crs = get_crs(self.body, "planetocentric")
         self._input_crs = get_crs(body, input_crs)
@@ -89,11 +103,19 @@ class CraterDatabase:
             raise ValueError("Could not read crater dataset.")
         self.orig_cols = in_data.columns
 
+        for col in (lat_col, lon_col, rad_col, diam_col):
+            if col is not None and col not in in_data.columns:
+                raise ValueError(f"Column '{col}' not found in dataset.")
+
         # Find lat, lon coord columns and create the point geometry
         # TODO: get centroid from geometry instead, if exists (need to handle antimeridian wrap)
         in_data = in_data.drop(columns="geometry", errors="ignore")
-        lats = pd.to_numeric(in_data[ch.findcol(in_data, ["latitude", "lat"])])
-        lons = pd.to_numeric(in_data[ch.findcol(in_data, ["longitude", "lon"])])
+        lats = pd.to_numeric(
+            in_data[lat_col or ch.findcol(in_data, ["latitude", "lat"])]
+        )
+        lons = pd.to_numeric(
+            in_data[lon_col or ch.findcol(in_data, ["longitude", "lon"])]
+        )
 
         # Create main GeoDataFrame with geometry coords in input_crs then standardize to self._crs
         transformer = Transformer.from_crs(self._input_crs, self._crs, always_xy=True)
@@ -113,9 +135,15 @@ class CraterDatabase:
         self.data["_lat"] = self.data.geometry.y
         self.data["_lon"] = self.data.geometry.x
 
-        # Look for radius / diam column, store as _radius_m
-        rcol = ch.find_rad_or_diam_col(self.data)
-        div = 2 if rcol.lower().startswith("d") else 1  # diam -> rad conversion
+        # Look for radius / diam column, store as _radius_m. An explicit rad_col
+        # or diam_col fixes the column (and whether to halve), else auto-detect.
+        if rad_col is not None:
+            rcol, div = rad_col, 1
+        elif diam_col is not None:
+            rcol, div = diam_col, 2
+        else:
+            rcol = ch.find_rad_or_diam_col(self.data)
+            div = 2 if rcol.lower().startswith("d") else 1  # diam -> rad conversion
         mul = 1000 if units == "km" else 1  # Convert km -> m
         self.data["_radius_m"] = pd.to_numeric(self.data[rcol]) * mul / div
 

--- a/craterpy/tests/test_classes.py
+++ b/craterpy/tests/test_classes.py
@@ -158,6 +158,37 @@ class TestCraterDatabase(unittest.TestCase):
             cdb = CraterDatabase(test_df, "moon")
             self.assertEqual(cdb.rad.iloc[0], 10.0)
 
+    def test_custom_columns(self):
+        """Test selecting lat/lon/rad/diam columns explicitly by name."""
+        df = pd.DataFrame(
+            {
+                "y": [0.0],
+                "x": [10.0],
+                "diam_robbins": [10.0],
+                "diam_other": [99.0],  # ambiguous extra column, must be ignored
+            }
+        )
+        cdb = CraterDatabase(
+            df, "moon", lat_col="y", lon_col="x", diam_col="diam_robbins"
+        )
+        self.assertEqual(cdb.lat.iloc[0], 0.0)
+        self.assertEqual(cdb.lon.iloc[0], 10.0)
+        self.assertEqual(cdb.rad.iloc[0], 5.0)  # diam halved
+
+        # rad_col is used as-is (not halved)
+        cdb = CraterDatabase(
+            df, "moon", lat_col="y", lon_col="x", rad_col="diam_robbins"
+        )
+        self.assertEqual(cdb.rad.iloc[0], 10.0)
+
+    def test_custom_columns_errors(self):
+        """Test validation of the column-selection kwargs."""
+        df = pd.DataFrame({"lat": [0.0], "lon": [0.0], "radius": [1.0]})
+        with self.assertRaises(ValueError):
+            CraterDatabase(df, "moon", rad_col="radius", diam_col="radius")
+        with self.assertRaises(ValueError):
+            CraterDatabase(df, "moon", lat_col="nope")
+
     def test_bool_and_eq(self):
         """Test __bool__ and __eq__ methods."""
         # Test empty database

--- a/craterpy/tests/test_crs.py
+++ b/craterpy/tests/test_crs.py
@@ -42,6 +42,21 @@ class TestCraterDatabase(unittest.TestCase):
         with self.assertRaises(ValueError):
             get_crs("mars", "invalid_crs")
 
+    def test_input_crs_passthrough_forms(self):
+        """The CRS forms accepted as CraterDatabase input_crs pass through get_crs."""
+        expected = CRS.from_user_input("IAU_2015:200000100")  # Ceres ocentric
+
+        # 1. Authority code string
+        self.assertEqual(get_crs("ceres", "IAU_2015:200000100"), expected)
+
+        # 2. pyproj.CRS object
+        self.assertEqual(get_crs("ceres", expected), expected)
+
+        # 3. proj4 string (the Ceres sphere, R=487300 m)
+        crs = get_crs("ceres", "+proj=longlat +R=487300 +no_defs")
+        self.assertIsInstance(crs, pyproj.CRS)
+        self.assertEqual(crs.ellipsoid.semi_major_metre, 487300)
+
     def test_unknown_body_or_system(self):
         """Test raises error for unknown crs."""
         with self.assertRaises(ValueError):

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -7,7 +7,7 @@ The basis of `craterpy` is the `CraterDatabase` which reads crater data, manages
 The `CraterDatabase` takes a table of craters with at least columns for latitude, longitude, and radius or diameter of the craters. The exact names of the columns are not strict, ex 'Lat' and 'rad' are recognized, but if multiple columns match, `craterpy` will assume the first is correct.
 
 ```{note}
-To choose specific columns or filter to desired rows, first read the table into a `pandas.DataFrame` and pass the filtered subset dataframe to `CraterDatabase`.
+To filter to desired rows, first read the table into a `pandas.DataFrame` and pass the filtered subset dataframe to `CraterDatabase`.
 ```
 
 Here we read a sample list of lunar craters, optionally filter it to keep only the largest and then improt it into a `CraterDatabase`:
@@ -28,6 +28,20 @@ print(cdb)
 # Moon CraterDatabase (N=222)
 ```
 
+If column names are ambiguous (e.g. a table with several diameter columns from different methodologies), name the latitude, longitude, and size columns explicitly. Use `diam_col` for a diameter column or `rad_col` for a radius column. All other columns are preserved for later analysis:
+
+```python
+from craterpy import CraterDatabase, sample_data
+import pandas as pd
+df = pd.read_csv(sample_data["moon_craters_km.csv"])
+cdb = CraterDatabase(
+    df, body="Moon", units="km",
+    lat_col="Latitude", lon_col="Longitude", diam_col="Diameter (km)",
+)
+print(cdb)
+# Moon CraterDatabase (N=786)
+```
+
 Planetary `body` is a required `CraterDatabase` parameter to ensure the correct coordinate reference system (CRS) is used (read more about CRS [here](https://docs.qgis.org/3.40/en/docs/gentle_gis_introduction/coordinate_reference_systems.html)). Supported bodies are given in `craterpy.all_bodies`. The CRS defaults to the `IAU_2015` CRS most commonly used for the particular body, see list [here](https://planetarynames.wr.usgs.gov/TargetCoordinates).  A custom input CRS for the crater coordinates can be specified as follows:
 
 ```python
@@ -37,6 +51,14 @@ print(all_bodies)
 
 custom_crs = "IAU_2015:200000100"  # Can be any CRS string recognized by pyproj
 cdb = CraterDatabase(sample_data["ceres_craters_km.csv"], "ceres", input_crs=custom_crs, units="km")
+
+# input_crs also accepts a pyproj.CRS object (must be on the same body)
+from pyproj import CRS
+custom_crs = CRS.from_user_input("IAU_2015:200000100")
+cdb = CraterDatabase(sample_data["ceres_craters_km.csv"], "ceres", input_crs=custom_crs, units="km")
+
+# ...or a proj4 string (here the Ceres sphere, R=487300 m)
+cdb = CraterDatabase(sample_data["ceres_craters_km.csv"], "ceres", input_crs="+proj=longlat +R=487300 +no_defs", units="km")
 ```
 
 ```{note}
@@ -155,7 +177,7 @@ The input raster file must be georeferenced and importable by `gdal`.
 
 First download the [Lunar Crater Database](https://pdsimage2.wr.usgs.gov/Individual_Investigations/moon_lro.kaguya_multi_craterdatabase_robbins_2018/data/) (Robbins, 2018) in CSV format. Currently `craterpy` works on any tabular data with a diam, lat, and lon column. Since crater databases are often not supplied in a standardized and labelled PDS format, some manual data cleaning may be necessary to ensure the correct columns, planetary body, and units are used.
 
-Here we read the data with `pandas` and filter to the desired columns and area. We rename the diam, lat, and lon columns for convenience, then pass only those columns to `CraterDatabase` to ensure `craterpy` uses the correct values (the Robbins CSV contains mulitple columns corresponding to each). Pre-filtering the region desired saves on computation time.
+Here we read the data with `pandas` and filter to the desired area. The Robbins CSV contains multiple columns for diameter, latitude, and longitude, so we point `CraterDatabase` at the ones we want with `diam_col`, `lat_col`, and `lon_col` (the rest are preserved). Pre-filtering the region desired saves on computation time.
 
 Here, taking only craters larger than 5km results in ~12500 craters vs. all craters larger than 1 km results in ~175k craters. On `craterpy v0.9.5` these took ~20s and ~5 minutes to plot, respectively (when tested on a Ryzen 7 laptop with 8 cores at 1.9 GHz and 24GB RAM).
 
@@ -163,15 +185,13 @@ Here, taking only craters larger than 5km results in ~12500 craters vs. all crat
 from craterpy import CraterDatabase, sample_data as sd
 import pandas as pd
 df = pd.read_csv('/home/cjtu/projects/craterpy/tmp/lunar_crater_database_robbins_2018.csv')
-df = df.rename(columns={'DIAM_CIRC_IMG':'diam', 'LAT_CIRC_IMG':'lat', 'LON_CIRC_IMG':'lon'})
-df = df[['diam', 'lat', 'lon']]
-df = df[(-70 < df.lat) & (df.lat < 30)
-        & (220 < df.lon) & (df.lon < 320)
-        & (1 < df.diam) & (df.diam < 300)]
+df = df[(-70 < df.LAT_CIRC_IMG) & (df.LAT_CIRC_IMG < 30)
+        & (220 < df.LON_CIRC_IMG) & (df.LON_CIRC_IMG < 320)
+        & (1 < df.DIAM_CIRC_IMG) & (df.DIAM_CIRC_IMG < 300)]
 
 # Subset to only 5 km and larger craters, plot on DEM
-df5 = df[(5 < df.diam)]
-cdb5 = CraterDatabase(df5, "Moon", units="km")
+df5 = df[(5 < df.DIAM_CIRC_IMG)]
+cdb5 = CraterDatabase(df5, "Moon", units="km", diam_col="DIAM_CIRC_IMG", lat_col="LAT_CIRC_IMG", lon_col="LON_CIRC_IMG")
 cdb5.plot(sd['moon_dem.tif'], alpha=0.3, color='k', savefig='readme_orientale_robbins_gt5.png')
 ```
 
@@ -180,7 +200,7 @@ cdb5.plot(sd['moon_dem.tif'], alpha=0.3, color='k', savefig='readme_orientale_ro
 
 ```python
 # Plot all craters >1km, this may take some time!
-cdb = CraterDatabase(df, "Moon", units="km")
+cdb = CraterDatabase(df, "Moon", units="km", diam_col="DIAM_CIRC_IMG", lat_col="LAT_CIRC_IMG", lon_col="LON_CIRC_IMG")
 cdb.plot(sd['moon_dem.tif'], alpha=0.3, color='k', savefig='readme_orientale_robbins.png')
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "craterpy"
-version = "0.11.1"
+version = "0.11.2"
 description = "Impact crater data science in Python."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -520,7 +520,7 @@ toml = [
 
 [[package]]
 name = "craterpy"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "antimeridian" },


### PR DESCRIPTION
Closes #105.

CraterDatabase auto-detects the latitude, longitude, and radius/diameter columns by name. That fails when a dataset has several candidates (for example diameters from multiple methodologies) because the first match wins, with no way to choose.

This PR adds four optional keyword-only arguments to CraterDatabase:

- lat_col, lon_col: use these columns instead of auto-detecting.
- rad_col, diam_col: name the size column explicitly. diam_col is halved to a radius, rad_col is taken as-is. Pass only one.

When omitted, behavior is unchanged (auto-detection still runs). Invalid input raises ValueError: naming a column that does not exist, or passing both rad_col and diam_col. All original columns are preserved as before, so extra methodology columns remain available for later analysis.

Example:

CraterDatabase(df, "moon", lat_col="y", lon_col="x", diam_col="DIAM_CIRC")
This covers the column-selection half of issue #105. 

The other half, a custom input CRS, is already supported today through the existing input_crs argument, which accepts an authority code string, a pyproj.CRS object, or a proj4 string (all must be on the same body). Add documentation for these options

Docs: the getting started guide gains a new block demonstrating the column-selection kwargs, the input_crs section now shows all three accepted CRS forms (authority string, pyproj.CRS object, proj4 string), the now-outdated note about using pandas to pick columns was corrected, and the Orientale example uses the new kwargs instead of manually renaming columns.

Tests: test_custom_columns and test_custom_columns_errors verify column selection, diameter-vs-radius handling, and the validation errors. test_input_crs_passthrough_forms verifies the three input_crs forms pass through get_crs.