### PR TITLE
Fix ROI sampling and plotting on projected rasters (#83)

### DIFF
--- a/craterpy/__init__.py
+++ b/craterpy/__init__.py
@@ -6,7 +6,9 @@ from craterpy.classes import CraterDatabase
 from craterpy.crs import ALL_BODIES
 
 data_dir = resources.files(__name__).joinpath("data")
-sample_data = {p.name: p for p in data_dir.rglob("*") if p.suffix in (".csv", ".tif")}
+sample_data = {
+    p.name: p for p in data_dir.rglob("*") if p.suffix in (".csv", ".tif", ".vrt")
+}
 all_bodies = ALL_BODIES
 __all__ = ["CraterDatabase", "sample_data"]
 

--- a/craterpy/classes.py
+++ b/craterpy/classes.py
@@ -643,7 +643,7 @@ class CraterDatabase:
         # projected raster, cartopy warps each mini raster into the geodetic axes.
         with rio.open(fraster) as src:
             transform = _img_transform(src.crs, pc, ch.bbox2extent(src.bounds))
-        gdf_r = ch.reproject_to_raster(gdf.geometry, fraster)
+            gdf_r = ch.reproject_to_raster(gdf.geometry, src)
 
         # Make roi array generator
         rois = gen_zonal_stats(
@@ -663,23 +663,23 @@ class CraterDatabase:
             subplot_kw={"projection": pc},
             gridspec_kw={"wspace": 0.4, "hspace": 0.2},
         )
-        i = 0
         axs = np.atleast_1d(axes).flatten()
-        while i < n:
-            img = next(rois)["mini_raster_array"]
+        # Loop through and generate plots and track number of valid rois plotted
+        ax_i = 0
+        for geom, geom_r, roi in zip(gdf.geometry, gdf_r, rois, strict=True):
+            img = roi["mini_raster_array"]
             if img.count() == 0:
                 n -= 1
                 continue
-            geom = gdf.geometry.iloc[i]  # geodetic, for outline + degree gridlines
-            extent = ch.bbox2extent(gdf_r.iloc[i].bounds)  # raster CRS, matches img
-            axs[i].imshow(
+            extent = ch.bbox2extent(geom_r.bounds)  # raster CRS, matches img
+            axs[ax_i].imshow(
                 img, extent=extent, aspect="auto", transform=transform, **im_kw
             )
-            axs[i].add_feature(ShapelyFeature(geom, crs=pc, **shp_kw))
+            axs[ax_i].add_feature(ShapelyFeature(geom, crs=pc, **shp_kw))
             # Frame on the geodetic crater bounds (warped images don't autoscale)
             gminx, gminy, gmaxx, gmaxy = geom.bounds
-            axs[i].set_extent((gminx, gmaxx, gminy, gmaxy), crs=pc)
-            i += 1
+            axs[ax_i].set_extent((gminx, gmaxx, gminy, gmaxy), crs=pc)
+            ax_i += 1
         # Format valid axes, delete unused axes
         for i, ax in enumerate(axs):
             if i >= n:

--- a/craterpy/classes.py
+++ b/craterpy/classes.py
@@ -10,6 +10,7 @@ import matplotlib.image as mpli
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import pyproj
 import rasterio as rio
 import shapely
 from cartopy.feature import ShapelyFeature
@@ -23,6 +24,27 @@ from craterpy.crs import get_crs
 
 # Default stats for rasterstats
 STATS = ("mean", "std", "count")
+
+
+def _img_transform(raster_crs, pc, bounds):
+    """Return the cartopy transform for displaying a raster on a geographic axis.
+
+    For a geographic (or unknown) raster CRS, the raster shares the axes
+    PlateCarree projection ``pc``. For a projected CRS, return a cartopy
+    Projection so cartopy warps the image into the geographic axes on draw.
+
+    ``bounds`` is the raster extent (xmin, xmax, ymin, ymax) in the raster CRS.
+    A custom (e.g. IAU) projected CRS has no ``area_of_use``, so cartopy can't
+    infer the projection domain; we set it explicitly from the raster bounds.
+    """
+    if raster_crs is None or pyproj.CRS.from_user_input(raster_crs).is_geographic:
+        return pc
+    proj = ccrs.Projection(pyproj.CRS.from_user_input(raster_crs))
+    if proj.bounds is None:
+        x0, x1, y0, y1 = bounds
+        proj.bounds = (x0, x1, y0, y1)
+        proj.threshold = min(x1 - x0, y1 - y0) / 100
+    return proj
 
 
 class CraterDatabase:
@@ -410,9 +432,9 @@ class CraterDatabase:
                 # By default does nearest-neighbor interp to out_shape (super fast reads for low dpi)
                 data = src.read(indexes=band, out_shape=(height_npix, width_npix))
                 extent = ch.bbox2extent(src.bounds)
-                # raster_crs = ccrs.CRS(src.crs)
-                # TODO: assumes simple cylindrical, recognize and support other projections
-                ax.imshow(data, cmap="gray", extent=extent, transform=proj)
+                # Geometries/axes stay geodetic; cartopy warps a projected raster on draw
+                transform = _img_transform(src.crs, proj, extent)
+                ax.imshow(data, cmap="gray", extent=extent, transform=transform)
         if not region:
             # Store crater rims with leading "_" to not be mistaken for user-defined ROIs
             region = "_plot_circles"
@@ -616,9 +638,16 @@ class CraterDatabase:
         )
         pc = ccrs.PlateCarree(globe=globe)
 
+        # rasterstats samples in the raster CRS; reproject geometries for clipping
+        # (axes/outlines stay geodetic so degree gridlines remain valid). For a
+        # projected raster, cartopy warps each mini raster into the geodetic axes.
+        with rio.open(fraster) as src:
+            transform = _img_transform(src.crs, pc, ch.bbox2extent(src.bounds))
+        gdf_r = ch.reproject_to_raster(gdf.geometry, fraster)
+
         # Make roi array generator
         rois = gen_zonal_stats(
-            gdf.geometry,
+            gdf_r,
             fraster,
             stats="count",
             raster_out=True,
@@ -641,10 +670,15 @@ class CraterDatabase:
             if img.count() == 0:
                 n -= 1
                 continue
-            geom = gdf.geometry.iloc[i]
-            extent = ch.bbox2extent(geom.bounds)
-            axs[i].imshow(img, extent=extent, aspect="auto", **im_kw)
+            geom = gdf.geometry.iloc[i]  # geodetic, for outline + degree gridlines
+            extent = ch.bbox2extent(gdf_r.iloc[i].bounds)  # raster CRS, matches img
+            axs[i].imshow(
+                img, extent=extent, aspect="auto", transform=transform, **im_kw
+            )
             axs[i].add_feature(ShapelyFeature(geom, crs=pc, **shp_kw))
+            # Frame on the geodetic crater bounds (warped images don't autoscale)
+            gminx, gminy, gmaxx, gmaxy = geom.bounds
+            axs[i].set_extent((gminx, gmaxx, gminy, gmaxy), crs=pc)
             i += 1
         # Format valid axes, delete unused axes
         for i, ax in enumerate(axs):

--- a/craterpy/data/images/README.md
+++ b/craterpy/data/images/README.md
@@ -2,6 +2,23 @@
 
 Files were drawn from the [USGS Astropedia](https://astrogeology.usgs.gov/search) site in Sep 2025.
 
+`moon_eqc.vrt` is a lightweight warped VRT giving a projected (meters) view of
+`moon.tif` in `IAU_2015:30110` (Moon Equirectangular, clon=0), used to test support
+for projected rasters. It references `moon.tif` relatively, so keep them together.
+Regenerate with:
+
+```python
+import rasterio as rio
+from rasterio.enums import Resampling
+from rasterio.shutil import copy as rio_copy
+from rasterio.vrt import WarpedVRT
+
+with rio.open("moon.tif") as src, WarpedVRT(
+    src, crs="IAU_2015:30110", resampling=Resampling.bilinear
+) as vrt:
+    rio_copy(vrt, "moon_eqc.vrt", driver="VRT")
+```
+
 To produce low resolution context images, the sample JPEG imagery of various planetary bodies were converted to `.tif` files using [GDAL](https://gdal.org/).
 
 ```sh

--- a/craterpy/data/images/moon_eqc.vrt
+++ b/craterpy/data/images/moon_eqc.vrt
@@ -1,0 +1,50 @@
+<VRTDataset rasterXSize="1024" rasterYSize="512" subClass="VRTWarpedDataset">
+  <SRS dataAxisToSRSAxisMapping="1,2">PROJCS["Moon (2015) - Sphere / Ocentric / Equirectangular, clon = 0",GEOGCS["Moon (2015) - Sphere / Ocentric",DATUM["Moon (2015) - Sphere",SPHEROID["Moon (2015) - Sphere",1737400,0,AUTHORITY["IAU","30100"]],AUTHORITY["IAU","30100"]],PRIMEM["Reference Meridian",0,AUTHORITY["IAU","30100"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["IAU","30100"]],PROJECTION["Equirectangular"],PARAMETER["standard_parallel_1",0],PARAMETER["central_meridian",0],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["IAU","30110"]]</SRS>
+  <GeoTransform> -5.4582030763469068e+06,  1.0660552883490051e+04,  0.0000000000000000e+00,  2.7291015381734534e+06,  0.0000000000000000e+00, -1.0660552883490051e+04</GeoTransform>
+  <VRTRasterBand dataType="Byte" band="1" subClass="VRTWarpedRasterBand">
+    <NoDataValue>0</NoDataValue>
+    <ColorInterp>Gray</ColorInterp>
+  </VRTRasterBand>
+  <BlockXSize>512</BlockXSize>
+  <BlockYSize>128</BlockYSize>
+  <GDALWarpOptions>
+    <WarpMemoryLimit>6.71089e+07</WarpMemoryLimit>
+    <ResampleAlg>Bilinear</ResampleAlg>
+    <WorkingDataType>Byte</WorkingDataType>
+    <Option name="UNIFIED_SRC_NODATA">YES</Option>
+    <Option name="INIT_DEST">NO_DATA</Option>
+    <Option name="ERROR_OUT_IF_EMPTY_SOURCE_WINDOW">FALSE</Option>
+    <SourceDataset relativeToVRT="1">moon.tif</SourceDataset>
+    <Transformer>
+      <ApproxTransformer>
+        <MaxError>0.125</MaxError>
+        <BaseTransformer>
+          <GenImgProjTransformer>
+            <SrcGeoTransform>-180,0.3515625,0,90,0,-0.3515625</SrcGeoTransform>
+            <SrcInvGeoTransform>512,2.84444444444444455,0,256,0,-2.84444444444444455</SrcInvGeoTransform>
+            <DstGeoTransform>-5458203.07634690683,10660.5528834900506,0,2729101.53817345342,0,-10660.5528834900506</DstGeoTransform>
+            <DstInvGeoTransform>512.000000000000114,9.38037652389207155e-05,0,256.000000000000057,0,-9.38037652389207155e-05</DstInvGeoTransform>
+            <ReprojectTransformer>
+              <ReprojectionTransformer>
+                <SourceSRS>GEOGCS["Moon (2015) - Sphere / Ocentric",DATUM["Moon (2015) - Sphere",SPHEROID["Moon (2015) - Sphere",1737400,0]],PRIMEM["Reference Meridian",0],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST]]</SourceSRS>
+                <TargetSRS>PROJCS["Moon (2015) - Sphere / Ocentric / Equirectangular, clon = 0",GEOGCS["Moon (2015) - Sphere / Ocentric",DATUM["Moon (2015) - Sphere",SPHEROID["Moon (2015) - Sphere",1737400,0,AUTHORITY["IAU","30100"]],AUTHORITY["IAU","30100"]],PRIMEM["Reference Meridian",0,AUTHORITY["IAU","30100"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["IAU","30100"]],PROJECTION["Equirectangular"],PARAMETER["standard_parallel_1",0],PARAMETER["central_meridian",0],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["IAU","30110"]]</TargetSRS>
+                <Options>
+                  <Option key="CENTER_LONG">0</Option>
+                  <Option key="AREA_OF_INTEREST">-180,-90,180,90</Option>
+                </Options>
+              </ReprojectionTransformer>
+            </ReprojectTransformer>
+          </GenImgProjTransformer>
+        </BaseTransformer>
+      </ApproxTransformer>
+    </Transformer>
+    <BandList>
+      <BandMapping src="1" dst="1">
+        <SrcNoDataReal>0</SrcNoDataReal>
+        <SrcNoDataImag>0</SrcNoDataImag>
+        <DstNoDataReal>0</DstNoDataReal>
+        <DstNoDataImag>0</DstNoDataImag>
+      </BandMapping>
+    </BandList>
+  </GDALWarpOptions>
+</VRTDataset>

--- a/craterpy/helper.py
+++ b/craterpy/helper.py
@@ -9,6 +9,7 @@ import joblib
 import numpy as np
 import pandas as pd
 import pyproj
+import rasterio as rio
 from joblib import Parallel, delayed
 from planetarypy.crs import local_crs
 from planetarypy.geo import split_at_antimeridian
@@ -355,6 +356,37 @@ def get_annular_buffer(point: Point, rad: float, inner: float, outer: float, **k
     return outer_poly.difference(inner_poly)
 
 
+def reproject_to_raster(geometries, raster):
+    """Return geometries reprojected to the raster's CRS.
+
+    rasterstats samples a raster using the geometry coordinates as-is and does not
+    reproject, so geometries must share the raster's CRS. This is a no-op when the
+    CRS already match or when either CRS is unknown.
+
+    Parameters
+    ----------
+    geometries : geopandas.GeoSeries
+        GeoSeries with a defined ``.crs``.
+    raster : str or rasterio.DatasetReader
+        Raster file path or open raster dataset.
+
+    Returns
+    -------
+    geopandas.GeoSeries
+        Geometries in the raster CRS (or unchanged if reprojection isn't needed).
+    """
+    if hasattr(raster, "crs"):
+        rcrs = raster.crs
+    else:
+        with rio.open(raster) as src:
+            rcrs = src.crs
+    if rcrs is None or geometries.crs is None:
+        return geometries
+    if pyproj.CRS.from_user_input(rcrs) == pyproj.CRS.from_user_input(geometries.crs):
+        return geometries
+    return geometries.to_crs(rcrs)
+
+
 def compute_zonal_stats(geometries, raster, suffix: str = "", **kwargs) -> pd.DataFrame:
     """
     Compute zonal stats (e.g., mean, std, count) for each geometry in the raster.
@@ -377,6 +409,8 @@ def compute_zonal_stats(geometries, raster, suffix: str = "", **kwargs) -> pd.Da
     pandas.DataFrame
         DataFrame containing computed statistics for each geometry.
     """
+    # rasterstats doesn't reproject; match the raster CRS first (e.g. projected rasters)
+    geometries = reproject_to_raster(geometries, raster)
     # Perform the core calculation
     zstats = zonal_stats(geometries, raster, all_touched=True, **kwargs)
     df = pd.DataFrame(zstats, index=geometries.index)
@@ -489,6 +523,8 @@ def compute_arrays(geometries, raster, suffix: str = "", **kwargs) -> pd.Series:
     pandas.Series
         Series of numpy.ma.MaskedArray, one clipped raster window per geometry.
     """
+    # rasterstats doesn't reproject; match the raster CRS first (e.g. projected rasters)
+    geometries = reproject_to_raster(geometries, raster)
     zstats = zonal_stats(
         geometries, raster, all_touched=True, raster_out=True, **kwargs
     )

--- a/craterpy/tests/test_classes.py
+++ b/craterpy/tests/test_classes.py
@@ -528,6 +528,54 @@ class TestCraterDatabase(unittest.TestCase):
             all(isinstance(ax, Axes) for ax in axes.flatten() if ax is not None)
         )
 
+        # Test saving plot_rois to file
+        with NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            tmp_path = tmp.name
+        try:
+            cdb.plot_rois(self.moon_tif, "test_region", index=1, savefig=tmp_path)
+            self.assertTrue(os.path.getsize(tmp_path) > 0)
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
+    def test_plot_rois_skips_empty(self):
+        """ROIs whose mini raster falls outside the data extent are skipped."""
+        from rasterio.transform import from_bounds
+
+        # Raster covering only a small equatorial patch near (lon, lat) = (0, 0)
+        with NamedTemporaryFile(suffix=".tif", delete=False) as tmp:
+            path = tmp.name
+        try:
+            with rio.open(
+                path,
+                "w",
+                driver="GTiff",
+                height=50,
+                width=50,
+                count=1,
+                dtype="uint8",
+                nodata=0,
+                crs="IAU_2015:30100",
+                transform=from_bounds(-10, -10, 10, 10, 50, 50),
+            ) as dst:
+                dst.write(np.ones((50, 50), dtype="uint8"), 1)
+
+            # Two craters inside the raster, one well outside (but not polar/oob):
+            # the outside one's window is all nodata, so its mini raster is empty.
+            df = pd.DataFrame(
+                {"lat": [3, -4, 0], "lon": [-3, 4, 120], "radius": [100, 100, 100]}
+            )
+            cdb = CraterDatabase(df, body="moon", units="km")
+            cdb.add_circles("test_region")
+
+            axes = cdb.plot_rois(path, "test_region", index=3)
+            # Only the two in-extent craters get an image; the outside one is skipped
+            drawn = [ax for ax in np.atleast_1d(axes).flatten() if ax.images]
+            self.assertEqual(len(drawn), 2)
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
+
     def test_projected_raster(self):
         """Sampling from or plotting on projected (meters) raster.
 

--- a/craterpy/tests/test_classes.py
+++ b/craterpy/tests/test_classes.py
@@ -28,6 +28,8 @@ class TestCraterDatabase(unittest.TestCase):
 
     def setUp(self):
         self.moon_tif = craterpy.sample_data["moon.tif"]
+        # projected (meters) view of moon.tif (IAU_2015:30110)
+        self.moon_vrt = craterpy.sample_data["moon_eqc.vrt"]
         self.moon_dem = craterpy.sample_data["moon_dem.tif"]
         self.moon_craters = craterpy.sample_data["moon_craters_km.csv"]
         self.vesta_tif = craterpy.sample_data["vesta.tif"]
@@ -525,3 +527,39 @@ class TestCraterDatabase(unittest.TestCase):
         self.assertTrue(
             all(isinstance(ax, Axes) for ax in axes.flatten() if ax is not None)
         )
+
+    def test_projected_raster(self):
+        """Sampling from or plotting on projected (meters) raster.
+
+        Geometries are stored geodetic (lat/lon), e.g. IAU_2015:30100 (Moon geodetic), while
+        ``moon_eqc.vrt`` is a VRT of moon.tif in IAU_2015:30110 (Moon Equirectangular, meters).
+        """
+        # Subset to a few large mid-latitude craters to keep the test fast
+        craters = pd.read_csv(self.moon_craters).head(12)
+        cdb = CraterDatabase(craters, "moon", units="km")
+        cdb.add_circles("crater", 1.0)
+
+        with rio.open(self.moon_vrt) as src:
+            self.assertFalse(src.crs.is_geographic)
+
+        # Stats/arrays must match the geographic raster: equivalent pixels are
+        # sampled (small differences only from warp resampling).
+        geo = cdb.get_stats(self.moon_tif, "crater", n_jobs=1)
+        proj = cdb.get_stats(self.moon_vrt, "crater", n_jobs=1)
+        self.assertTrue((proj["count_crater"] > 0).all())
+        np.testing.assert_allclose(proj["mean_crater"], geo["mean_crater"], atol=10)
+
+        arrays = cdb.get_arrays(self.moon_vrt, "crater", n_jobs=1)
+        self.assertTrue(all(a.count() > 0 for a in arrays["crater"]))
+
+        # plot(): warps raster into the geodetic axes with the ROI overlay
+        ax = cdb.plot(self.moon_vrt, region="crater", size=4, dpi=50)
+        self.assertEqual(len(ax.images), 1)
+        self.assertEqual(len(ax.collections), 1)
+
+        # plot_rois(): mini rasters are non-empty (correctly clipped)
+        axes = cdb.plot_rois(self.moon_vrt, "crater", index=3)
+        self.assertTrue(
+            all(isinstance(ax, Axes) for ax in axes.flatten() if ax is not None)
+        )
+        self.assertTrue(any(len(ax.images) > 0 for ax in axes.flatten()))

--- a/craterpy/tests/test_helper.py
+++ b/craterpy/tests/test_helper.py
@@ -205,6 +205,36 @@ class TestShapeGeometryHelpers(unittest.TestCase):
         self.assertEqual(south.bounds[2], 180.0)
         self.assertEqual(south.bounds[1], -90.0)
 
+    def test_reproject_to_raster(self):
+        """Geometries are reprojected to the raster CRS only when needed."""
+        import geopandas as gpd
+        import pyproj
+        import rasterio as rio
+
+        import craterpy
+
+        geom = gpd.GeoSeries([Point(0, 0), Point(10, 20)], crs="IAU_2015:30100")
+
+        # No-op when the geometry CRS is unknown
+        nocrs = gpd.GeoSeries([Point(0, 0)])
+        out = ch.reproject_to_raster(nocrs, craterpy.sample_data["moon_eqc.vrt"])
+        self.assertIs(out, nocrs)
+
+        # No-op when geometries already match the (geographic) raster CRS
+        out = ch.reproject_to_raster(geom, craterpy.sample_data["moon.tif"])
+        self.assertIs(out, geom)
+
+        # Reproject to a projected raster; an already-open dataset is accepted
+        with rio.open(craterpy.sample_data["moon_eqc.vrt"]) as src:
+            rcrs = src.crs
+            out = ch.reproject_to_raster(geom, src)
+        self.assertEqual(
+            pyproj.CRS.from_user_input(out.crs), pyproj.CRS.from_user_input(rcrs)
+        )
+        self.assertFalse(out.crs.is_geographic)
+        # Degrees became meters, so coordinates are now large
+        self.assertGreater(abs(out.iloc[1].x), 1e5)
+
 
 class TestDataframeHelpers(unittest.TestCase):
     """Test pandas.DataFrame helper functions"""


### PR DESCRIPTION
rasterstats samples a raster using geometry coordinates as-is without reprojecting. Since CraterDatabase geometries are stored geodetic (lat/lon), sampling or plotting against a projected (meters) raster silently used lat/lon coordinates in a meters CRS — so plot_rois() plotted ROIs at the wrong locations and stats/arrays were sampled from the wrong pixels.

Fix

- Reproject geometries to the raster CRS before sampling. New helper reproject_to_raster() (a no-op when CRS match or are unknown) is applied in compute_zonal_stats and compute_arrays.
- Keep axes/outlines geodetic for plotting. New helper _img_transform() returns a cartopy Projection for projected rasters so cartopy warps the image into the geodetic axes on draw, while geometry outlines and degree gridlines stay valid. Applied in both plot() and plot_rois().
- ROI mini-rasters in plot_rois() now use the reprojected geometry bounds for extent, with the frame set on the geodetic bounds (warped images don't autoscale).

Testing

- Added moon_eqc.vrt — a lightweight WarpedVRT of moon.tif in IAU_2015:30110 (Moon Equirectangular, meters) — as a projected-raster fixture (regeneration steps documented in data/images/README.md).
- New test_projected_raster verifies stats/arrays match the geographic raster (within warp-resampling tolerance) and that plot()/plot_rois() produce non-empty, correctly clipped output.

Closes #83 