### PR TITLE
Fix #71 isolated isntance properties from class properties

### DIFF
--- a/craterpy/classes.py
+++ b/craterpy/classes.py
@@ -124,6 +124,7 @@ class CraterDatabase:
         else:
             raise ValueError("Could not read crater dataset.")
         self.orig_cols = in_data.columns
+        self._roi_names = {}  # attr name -> data column name (per-instance ROIs)
 
         for col in (lat_col, lon_col, rad_col, diam_col):
             if col is not None and col not in in_data.columns:
@@ -172,6 +173,17 @@ class CraterDatabase:
     def __repr__(self):
         attrs = ", ".join([p for p in self._get_properties() if not p.startswith("_")])
         return f"CraterDatabase of length {len(self.data)} with attributes {attrs}."
+
+    def __getattr__(self, name):
+        """Expose per-instance ROI columns as attributes (e.g. cdb.ejecta)."""
+        # __getattr__ only runs when normal lookup fails. Use __dict__ to avoid
+        # recursing through __getattr__ before _roi_names is set in __init__.
+        rois = self.__dict__.get("_roi_names", {})
+        if name in rois:
+            return self.data[rois[name]]
+        raise AttributeError(
+            f"{type(self).__name__!r} object has no attribute {name!r}"
+        )
 
     def __str__(self):
         body = self.body.capitalize()
@@ -222,14 +234,15 @@ class CraterDatabase:
         return out
 
     def _make_data_property(self, col):
-        """Make a column of self.data accessible directly as an attribute."""
+        """Register a column of self.data for direct attribute access on this instance."""
         c = col.replace(" ", "_")  # attr can't have spaces
-        setattr(self.__class__, c, property(fget=lambda self: self.data[col]))
+        self._roi_names[c] = col
 
     def _get_properties(self):
-        """Return list of property names."""
+        """Return list of attribute names (class properties + this instance's ROIs)."""
         class_items = self.__class__.__dict__.items()
-        return [k for k, v in class_items if isinstance(v, property)]
+        props = [k for k, v in class_items if isinstance(v, property)]
+        return props + list(self._roi_names)
 
     @property
     def lat(self):

--- a/craterpy/tests/test_classes.py
+++ b/craterpy/tests/test_classes.py
@@ -54,6 +54,21 @@ class TestCraterDatabase(unittest.TestCase):
         # Test that ejecta was registered as a propety and contains a shapely geom
         self.assertIsInstance(cdb.ejecta[0], shapely.geometry.Polygon)
 
+    def test_roi_attrs_are_per_instance(self):
+        """ROIs added to one database must not leak into another (issue #71)."""
+        a = self.moon_cdb.copy()
+        b = self.moon_cdb.copy()
+        a.add_annuli("new", 1, 3)
+
+        # "new" belongs to a only
+        self.assertIn("new", a.__repr__())
+        self.assertIsInstance(a.new[0], shapely.geometry.Polygon)
+
+        # b must not report or expose "new"
+        self.assertNotIn("new", b.__repr__())
+        with self.assertRaises(AttributeError):
+            _ = b.new
+
     def test_get_stats(self):
         """Test getting statistics on a region for a raster."""
         stats = self.moon_cdb_rim.get_stats(self.moon_tif, "rim")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "craterpy"
-version = "0.11.2"
+version = "0.11.3"
 description = "Impact crater data science in Python."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -520,7 +520,7 @@ toml = [
 
 [[package]]
 name = "craterpy"
-version = "0.11.2"
+version = "0.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "antimeridian" },


### PR DESCRIPTION
Problem

ROIs added via add_annuli/add_circles were registered as property objects on the class (setattr(self.__class__, ...)), not the instance. As a result, an ROI added to one CraterDatabase appeared on every instance — its name showed up in the repr but accessing it raised KeyError because the column only existed in the originatin

a = CraterDatabase(crater_list, 'moon
b = CraterDatabase(crater_list, 'moon')
a.add_annuli('new', 1, 3)
print(b)      # ...includes "new"  ← wrong
b.new         # KeyError            ←

Fix

Track ROIs per-instance instead of polluting the class:

- New self._roi_names dict (attr name → data column) populated by _make_data_property.
- __getattr__ resolves registered ROInames to self.data column, preserving the convenient cdb.ejecta access and raising a proper AttributeError for unknown names. It reads _roi_names via self.__dict__ to avoid recursion before __init__ sets it (also safe under deepcopy/copy).
- _get_properties/__repr__ now combine the static class properties with the instance's own ROIs.

After the fix, b no longer reports or exposes new, and b.new raises AttributeError.

Tests

- Added test_roi_attrs_are_per_instance: adds an ROI to one copy and asserts it's present on that instance but absent from another's repr and raises AttributeError on access.

Other

- Version bump 0.11.2 → 0.11.3 (+ uv.lock sync).

Closes #71